### PR TITLE
Implementar reseteo de contraseña por email

### DIFF
--- a/actions/forgot-password-action.ts
+++ b/actions/forgot-password-action.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { getUserByEmail } from "@/lib/user-utils";
+import { nanoid } from "nanoid";
+import { sendPasswordResetEmail } from "@/lib/mail"; // Necesitaremos crear esta función
+
+export const forgotPassword = async (email: string) => {
+  // Validar el email (aunque Zod ya lo hace en el cliente, es bueno validar en el servidor también)
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return { error: "Email inválido." };
+  }
+
+  const existingUser = await getUserByEmail(email);
+
+  if (!existingUser) {
+    // No revelar si el usuario existe o no por seguridad
+    // Simplemente retornar un mensaje genérico
+    return { success: "Si existe una cuenta con ese email, recibirás un enlace para resetear tu contraseña." };
+  }
+
+  // Generar token de reseteo
+  const token = nanoid();
+  const expires = new Date(Date.now() + 1000 * 60 * 60 * 1); // 1 hora de expiración
+
+  // Eliminar tokens de reseteo existentes para este usuario
+  await db.passwordResetToken.deleteMany({
+    where: { identifier: existingUser.email },
+  });
+
+  // Guardar el nuevo token en la base de datos
+  await db.passwordResetToken.create({
+    data: {
+      identifier: existingUser.email,
+      token,
+      expires,
+    },
+  });
+
+  // Enviar email con el enlace de reseteo
+  // El enlace debería apuntar a algo como /reset-password?token=TOKEN_AQUI
+  const resetLink = `${process.env.NEXTAUTH_URL}/reset-password?token=${token}`;
+
+  try {
+    await sendPasswordResetEmail(existingUser.email, resetLink); // Esta función se creará en lib/mail.ts
+    return { success: "Si existe una cuenta con ese email, recibirás un enlace para resetear tu contraseña." };
+  } catch (error) {
+    console.error("Error al enviar email de reseteo:", error);
+    return { error: "No se pudo enviar el email de reseteo. Intenta de nuevo más tarde." };
+  }
+};

--- a/actions/reset-password-action.ts
+++ b/actions/reset-password-action.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { getUserByEmail } from "@/lib/user-utils";
+import bcrypt from "bcryptjs";
+
+export const resetPassword = async (token: string, newPassword: string) => {
+  if (!token) {
+    return { error: "Token no proporcionado." };
+  }
+
+  if (!newPassword || newPassword.length < 6) {
+    return { error: "La contraseña debe tener al menos 6 caracteres." };
+  }
+
+  const existingToken = await db.passwordResetToken.findUnique({
+    where: { token },
+  });
+
+  if (!existingToken) {
+    return { error: "Token inválido o no encontrado." };
+  }
+
+  if (existingToken.expires < new Date()) {
+    // Opcionalmente, eliminar el token expirado
+    await db.passwordResetToken.delete({ where: { token } }).catch(console.error);
+    return { error: "El token ha expirado. Por favor, solicita un nuevo reseteo." };
+  }
+
+  const user = await getUserByEmail(existingToken.identifier);
+
+  if (!user) {
+    // Esto no debería suceder si el token es válido y está asociado a un email existente
+    console.error(`Usuario no encontrado para el token: ${token}, email: ${existingToken.identifier}`);
+    return { error: "Usuario no encontrado. Contacta a soporte." };
+  }
+
+  // Hashear la nueva contraseña
+  const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+  // Actualizar la contraseña del usuario
+  try {
+    await db.user.update({
+      where: { email: existingToken.identifier },
+      data: { password: hashedPassword },
+    });
+  } catch (error) {
+    console.error("Error al actualizar la contraseña del usuario:", error);
+    return { error: "No se pudo actualizar la contraseña. Intenta de nuevo." };
+  }
+
+  // Eliminar el token de reseteo una vez usado
+  try {
+    await db.passwordResetToken.delete({
+      where: { token },
+    });
+  } catch (error) {
+    // No es crítico si falla, pero loguear
+    console.warn(`No se pudo eliminar el token de reseteo usado: ${token}`, error);
+  }
+
+  return { success: "¡Tu contraseña ha sido reseteada exitosamente!" };
+};

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,11 @@
+import ForgotPasswordForm from "@/components/forgot-password-form";
+
+const ForgotPasswordPage = () => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen py-2">
+      <ForgotPasswordForm />
+    </div>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,15 +1,45 @@
-import FormLogin from "@/components/form-login"
+import FormLogin from "@/components/form-login";
 
 interface LoginPageProps {
-  searchParams: Promise<{ verified?: string; error?: string }>
+  searchParams: {
+    verified?: string;
+    error?: string;
+    passwordReset?: string; // Para mensaje de contraseña reseteada
+    // Errores de las páginas de forgot-password y reset-password
+    tokenError?: "invalid_token" | "expired_token";
+  };
 }
 
-const LoginPage = async ({ searchParams }: LoginPageProps) => {
-  const params = await searchParams
-  const isVerified = params.verified === "true"
-  const OAuthAccountNotLinked = params.error === "OAuthAccountNotLinked"
+// No es necesario que sea async si accedemos a searchParams directamente
+const LoginPage = ({ searchParams }: LoginPageProps) => {
+  const isVerified = searchParams.verified === "true";
+  const OAuthAccountNotLinked = searchParams.error === "OAuthAccountNotLinked";
+  const passwordResetSuccess = searchParams.passwordReset === "true";
+  const tokenError = searchParams.tokenError; // Puede ser 'invalid_token' o 'expired_token'
 
-  return <FormLogin isVerified={isVerified} OAuthAccountNotLinked={OAuthAccountNotLinked} />
-}
+  let bottomMessage: string | null = null;
+  let messageType: "success" | "error" = "success";
 
-export default LoginPage
+  if (passwordResetSuccess) {
+    bottomMessage = "¡Tu contraseña ha sido reseteada exitosamente! Ya puedes iniciar sesión.";
+    messageType = "success";
+  } else if (tokenError === "invalid_token") {
+    bottomMessage = "El enlace para resetear la contraseña es inválido o ya ha sido utilizado. Por favor, solicita uno nuevo.";
+    messageType = "error";
+  } else if (tokenError === "expired_token") {
+    bottomMessage = "El enlace para resetear la contraseña ha expirado. Por favor, solicita uno nuevo.";
+    messageType = "error";
+  }
+
+
+  return (
+    <FormLogin
+      isVerified={isVerified}
+      OAuthAccountNotLinked={OAuthAccountNotLinked}
+      bottomMessage={bottomMessage}
+      messageType={messageType}
+    />
+  );
+};
+
+export default LoginPage;

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,43 @@
+import ResetPasswordForm from "@/components/reset-password-form";
+import { db } from "@/lib/db";
+import { redirect } from "next/navigation";
+
+interface ResetPasswordPageProps {
+  searchParams: { [key: string]: string | string[] | undefined };
+}
+
+const ResetPasswordPage = async ({ searchParams }: ResetPasswordPageProps) => {
+  const token = searchParams.token as string | undefined;
+
+  if (!token) {
+    // Podríamos redirigir a una página de error o a forgot-password con un mensaje
+    console.warn("Token no encontrado en los parámetros de búsqueda.");
+    redirect("/forgot-password?error=invalid_token");
+  }
+
+  // Validar el token en el servidor
+  const passwordResetToken = await db.passwordResetToken.findUnique({
+    where: { token },
+  });
+
+  if (!passwordResetToken) {
+    console.warn(`Token de reseteo no encontrado en DB: ${token}`);
+    redirect("/forgot-password?error=invalid_token");
+  }
+
+  if (passwordResetToken.expires < new Date()) {
+    console.warn(`Token de reseteo expirado: ${token}`);
+    // Opcionalmente, eliminar el token expirado de la DB
+    await db.passwordResetToken.delete({ where: { token } }).catch(console.error);
+    redirect("/forgot-password?error=expired_token");
+  }
+
+  // Si el token es válido y no ha expirado, mostrar el formulario
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen py-2">
+      <ResetPasswordForm token={token} />
+    </div>
+  );
+};
+
+export default ResetPasswordPage;

--- a/components/forgot-password-form.tsx
+++ b/components/forgot-password-form.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { toast } from "sonner";
+import { useState, useTransition } from "react";
+import { forgotPassword } from "@/actions/forgot-password-action";
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email({ message: "Por favor ingrese un email válido." }),
+});
+
+type ForgotPasswordFormValues = z.infer<typeof forgotPasswordSchema>;
+
+export default function ForgotPasswordForm() {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const form = useForm<ForgotPasswordFormValues>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: {
+      email: "",
+    },
+  });
+
+  const onSubmit = (values: ForgotPasswordFormValues) => {
+    setError(null);
+    setSuccess(null);
+
+    startTransition(async () => {
+      const result = await forgotPassword(values.email);
+      if (result?.error) {
+        setError(result.error);
+        toast.error(result.error);
+      }
+      if (result?.success) {
+        setSuccess(result.success);
+        toast.success(result.success);
+        form.reset();
+      }
+    });
+  };
+
+  return (
+    <div className="w-full max-w-md p-8 space-y-8 bg-white rounded-lg shadow-md">
+      <div className="text-center">
+        <h1 className="text-3xl font-bold">¿Olvidaste tu contraseña?</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          No te preocupes. Ingresa tu email y te enviaremos un enlace para resetearla.
+        </p>
+      </div>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="tuemail@ejemplo.com"
+                    {...field}
+                    disabled={isPending}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          {error && (
+            <div className="p-3 text-sm text-red-700 bg-red-100 border border-red-300 rounded-md">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="p-3 text-sm text-green-700 bg-green-100 border border-green-300 rounded-md">
+              {success}
+            </div>
+          )}
+          <Button type="submit" className="w-full" disabled={isPending}>
+            {isPending ? "Enviando..." : "Enviar enlace de reseteo"}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/components/form-login.tsx
+++ b/components/form-login.tsx
@@ -19,13 +19,20 @@ import ButtonSocial from "./button-social"
 import { Eye, EyeOff, Loader2, Github, Mail } from "lucide-react"
 
 interface FormLoginProps {
-  isVerified?: boolean
-  OAuthAccountNotLinked?: boolean
+  isVerified?: boolean;
+  OAuthAccountNotLinked?: boolean;
+  bottomMessage?: string | null;
+  messageType?: "success" | "error";
 }
 
-const FormLogin = ({ isVerified, OAuthAccountNotLinked }: FormLoginProps) => {
-  const [isPending, startTransition] = useTransition()
-  const [showPassword, setShowPassword] = useState(false)
+const FormLogin = ({
+  isVerified,
+  OAuthAccountNotLinked,
+  bottomMessage,
+  messageType = "success", // Default to success
+}: FormLoginProps) => {
+  const [isPending, startTransition] = useTransition();
+  const [showPassword, setShowPassword] = useState(false);
   const router = useRouter()
 
   const form = useForm<z.infer<typeof loginSchema>>({
@@ -154,6 +161,17 @@ const FormLogin = ({ isVerified, OAuthAccountNotLinked }: FormLoginProps) => {
                     </FormItem>
                   )}
                 />
+
+                {/* Mostrar mensaje de error/éxito de reseteo de contraseña */}
+                {bottomMessage && (
+                  <div className={`p-3 text-sm rounded-md ${
+                    messageType === "error"
+                      ? "text-red-700 bg-red-100 border border-red-300"
+                      : "text-green-700 bg-green-100 border border-green-300"
+                  }`}>
+                    {bottomMessage}
+                  </div>
+                )}
 
                 <Button
                   type="submit"

--- a/components/reset-password-form.tsx
+++ b/components/reset-password-form.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { toast } from "sonner";
+import { useState, useTransition } from "react";
+import { resetPassword } from "@/actions/reset-password-action";
+
+const resetPasswordSchema = z
+  .object({
+    password: z
+      .string()
+      .min(6, { message: "La contraseña debe tener al menos 6 caracteres." }),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Las contraseñas no coinciden.",
+    path: ["confirmPassword"], // Path del error para que se muestre en el campo correcto
+  });
+
+type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;
+
+interface ResetPasswordFormProps {
+  token: string;
+}
+
+export default function ResetPasswordForm({ token }: ResetPasswordFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const form = useForm<ResetPasswordFormValues>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
+  });
+
+  const onSubmit = (values: ResetPasswordFormValues) => {
+    setError(null);
+    setSuccess(null);
+
+    startTransition(async () => {
+      const result = await resetPassword(token, values.password);
+      if (result?.error) {
+        setError(result.error);
+        toast.error(result.error);
+      }
+      if (result?.success) {
+        setSuccess(result.success);
+        toast.success(result.success);
+        form.reset();
+        // Redirigir al login después de un breve retraso
+        setTimeout(() => {
+          window.location.href = "/login?passwordReset=true";
+        }, 2000);
+      }
+    });
+  };
+
+  return (
+    <div className="w-full max-w-md p-8 space-y-8 bg-white rounded-lg shadow-md">
+      <div className="text-center">
+        <h1 className="text-3xl font-bold">Resetea tu Contraseña</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Ingresa tu nueva contraseña a continuación.
+        </p>
+      </div>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Nueva Contraseña</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="********"
+                    {...field}
+                    disabled={isPending}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirmar Nueva Contraseña</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="********"
+                    {...field}
+                    disabled={isPending}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          {error && (
+            <div className="p-3 text-sm text-red-700 bg-red-100 border border-red-300 rounded-md">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="p-3 text-sm text-green-700 bg-green-100 border border-green-300 rounded-md">
+              {success}
+            </div>
+          )}
+          <Button type="submit" className="w-full" disabled={isPending}>
+            {isPending ? "Reseteando..." : "Resetear Contraseña"}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/lib/email-templates.ts
+++ b/lib/email-templates.ts
@@ -890,3 +890,108 @@ export const emailVerificationTemplate = (verificationToken: string, verifyUrl: 
     </html>
   `
 }
+
+
+export const passwordResetTemplate = (resetLink: string): string => {
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Reseteo de Contraseña</title>
+        <style>
+          body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+          }
+          .container {
+            background-color: #f9f9f9;
+            padding: 30px;
+            border-radius: 10px;
+            border: 1px solid #ddd;
+          }
+          .header {
+            text-align: center;
+            margin-bottom: 30px;
+          }
+          .header h1 {
+            color: #2c3e50;
+            margin: 0;
+          }
+          .content {
+            background-color: white;
+            padding: 25px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+          }
+          .button {
+            display: inline-block;
+            background-color: #e74c3c; /* Color diferente para reseteo */
+            color: white;
+            padding: 12px 30px;
+            text-decoration: none;
+            border-radius: 5px;
+            font-weight: bold;
+            margin: 20px 0;
+          }
+          .button:hover {
+            background-color: #c0392b;
+          }
+          .footer {
+            text-align: center;
+            font-size: 12px;
+            color: #666;
+            margin-top: 20px;
+          }
+          .link-text {
+            background-color: #f8f9fa;
+            padding: 10px;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 14px;
+            border: 1px solid #e9ecef;
+            margin: 10px 0;
+            word-break: break-all;
+          }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <div class="header">
+            <h1>Reseteo de Contraseña</h1>
+          </div>
+
+          <div class="content">
+            <h2>¿Olvidaste tu contraseña?</h2>
+            <p>Hemos recibido una solicitud para resetear la contraseña de tu cuenta.</p>
+            <p>Haz clic en el siguiente botón para establecer una nueva contraseña:</p>
+
+            <div style="text-align: center;">
+              <a href="${resetLink}" class="button">Resetear Contraseña</a>
+            </div>
+
+            <p>Si el botón no funciona, puedes copiar y pegar el siguiente enlace en tu navegador:</p>
+            <div class="link-text">${resetLink}</div>
+
+            <p><strong>Importante:</strong></p>
+            <ul>
+              <li>Este enlace expirará en 1 hora.</li>
+              <li>Si no solicitaste un reseteo de contraseña, puedes ignorar este email de forma segura.</li>
+              <li>Por tu seguridad, no compartas este enlace con nadie.</li>
+            </ul>
+          </div>
+
+          <div class="footer">
+            <p>Este es un email automático, por favor no respondas a este mensaje.</p>
+            <p>&copy; ${new Date().getFullYear()} ${process.env.SMTP_FROM_NAME || "Tu Tienda"}. Todos los derechos reservados.</p>
+          </div>
+        </div>
+      </body>
+    </html>
+  `
+}

--- a/lib/mail.ts
+++ b/lib/mail.ts
@@ -1,26 +1,48 @@
 import { Resend } from "resend";
+import { passwordResetTemplate, emailVerificationTemplate } from "./email-templates"; // Importar la nueva plantilla
 
-const resend = new Resend("re_Wv8HFRk8_FfCVr9F1qinHVwh3gGq7Euv4");
+const resend = new Resend(process.env.AUTH_RESEND_KEY);
 
-export const sendEmailVerification = async (email: string, token: string) => {
+export const sendEmailVerification = async (email: string, verificationUrl: string) => { // Cambiado token por verificationUrl para consistencia
   try {
+    const htmlBody = emailVerificationTemplate(verificationUrl, verificationUrl); // Asumiendo que el template toma la URL directamente
+
     await resend.emails.send({
-      from: "NextAuth js <onboarding@resend.dev>",
+      from: `${process.env.SMTP_FROM_NAME || "Tu Tienda"} <${process.env.SMTP_FROM_EMAIL || "noreply@tutienda.com"}>`,
       to: email,
       subject: "Verify your email",
-      html: `
-        <p>Click the link below to verify your email</p>
-        <a href="${process.env.NEXTAUTH_URL}/api/auth/verify-email?token=${token}">Verify email</a>
-      `,
+      html: htmlBody, // Usar la plantilla generada
     });
 
     return {
       success: true,
     };
   } catch (error) {
-    console.log(error);
+    console.error("Error enviando email de verificación:", error); // Mejor log de error
     return {
-      error: true,
+      error: "Error enviando email de verificación.", // Mensaje de error más específico
+    };
+  }
+};
+
+export const sendPasswordResetEmail = async (email: string, resetLink: string) => {
+  try {
+    const htmlBody = passwordResetTemplate(resetLink); // Usar la nueva plantilla
+
+    await resend.emails.send({
+      from: `${process.env.SMTP_FROM_NAME || "Tu Tienda"} <${process.env.SMTP_FROM_EMAIL || "noreply@tutienda.com"}>`,
+      to: email,
+      subject: "Resetea tu contraseña",
+      html: htmlBody,
+    });
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    console.error("Error enviando email de reseteo de contraseña:", error);
+    return {
+      error: "Error enviando email de reseteo de contraseña.",
     };
   }
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,9 +4,26 @@ import authConfig from "./auth.config";
 
 const { auth } = NextAuth(authConfig);
 
-const publicRoutes = ["/", "/nosotros","/cart","/productos","/blog","/checkout","/contactenos","/api/email/send-verification","/terminos-y-condiciones","/politica-de-privacidad","/libro-de-reclamaciones","/promociones","/catalogo"];
-const publicPrefixes = ["/productos/","/blog/"];
-const authRoutes = ["/login", "/register"];
+// Añadir las nuevas rutas a publicRoutes para que sean accesibles sin login
+const publicRoutes = [
+  "/",
+  "/nosotros",
+  "/cart",
+  "/productos",
+  "/blog",
+  "/checkout",
+  "/contactenos",
+  "/api/email/send-verification", // Esta ya estaba, es para la verificación de email
+  "/terminos-y-condiciones",
+  "/politica-de-privacidad",
+  "/libro-de-reclamaciones",
+  "/promociones",
+  "/catalogo",
+  "/forgot-password", // Nueva ruta pública
+  "/reset-password", // Nueva ruta pública
+];
+const publicPrefixes = ["/productos/", "/blog/"];
+const authRoutes = ["/login", "/register"]; // Estas son las páginas a las que se redirige si ya está logueado
 const apiAuthPrefix = "/api/auth";
 
 export default auth((req) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,11 @@
     "": {
       "name": "auth-temp",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.9.1",
         "@hookform/resolvers": "^5.0.1",
-        "@prisma/client": "^6.8.2",
+        "@prisma/client": "^6.10.1",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-avatar": "^1.1.9",
         "@radix-ui/react-checkbox": "^1.3.1",
@@ -58,6 +59,7 @@
         "@types/nodemailer": "^6.4.17",
         "@types/react": "^19.1.4",
         "@types/react-dom": "^19.1.5",
+        "prisma": "^6.10.1",
         "tw-animate-css": "^1.3.0",
         "typescript": "^5"
       }
@@ -769,9 +771,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.8.2.tgz",
-      "integrity": "sha512-5II+vbyzv4si6Yunwgkj0qT/iY0zyspttoDrL3R4BYgLdp42/d2C8xdi9vqkrYtKt9H32oFIukvyw3Koz5JoDg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.10.1.tgz",
+      "integrity": "sha512-Re4pMlcUsQsUTAYMK7EJ4Bw2kg3WfZAAlr8GjORJaK4VOP6LxRQUQ1TuLnxcF42XqGkWQ36q5CQF1yVadANQ6w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -788,6 +790,66 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
+      "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
+      "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
+      "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/fetch-engine": "6.10.1",
+        "@prisma/get-platform": "6.10.1"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
+      "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
+      "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/get-platform": "6.10.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
+      "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.1"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3740,6 +3802,32 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
+      "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.10.1",
+        "@prisma/engines": "6.10.1"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/proxy-from-env": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@auth/prisma-adapter": "^2.9.1",
     "@hookform/resolvers": "^5.0.1",
-    "@prisma/client": "^6.8.2",
+    "@prisma/client": "^6.10.1",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.9",
     "@radix-ui/react-checkbox": "^1.3.1",
@@ -60,6 +60,7 @@
     "@types/nodemailer": "^6.4.17",
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",
+    "prisma": "^6.10.1",
     "tw-animate-css": "^1.3.0",
     "typescript": "^5"
   }

--- a/prisma/migrations/20250624201913_added_password_reset_token/migration.sql
+++ b/prisma/migrations/20250624201913_added_password_reset_token/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "clefast"."PasswordResetToken" (
+    "identifier" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("identifier")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_identifier_key" ON "clefast"."PasswordResetToken"("identifier");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,15 @@ model VerificationToken {
   @@schema("clefast")
 }
 
+model PasswordResetToken {
+  identifier String   @unique
+  token      String
+  expires    DateTime
+
+  @@id([identifier])
+  @@schema("clefast")
+}
+
 // New model for user addresses
 model Address {
   id              String    @id @default(cuid())


### PR DESCRIPTION
Se ha añadido la funcionalidad completa para que los usuarios puedan resetear su contraseña si la olvidan:

- Creación de modelos y migraciones para PasswordResetToken.
- Páginas y formularios para solicitar el reseteo y para ingresar la nueva contraseña.
- Acciones de servidor para manejar la lógica de generación de token, envío de email y actualización de contraseña.
- Plantillas de email para el enlace de reseteo.
- Actualización de rutas y middleware para permitir acceso público a las nuevas páginas.
- Mejoras en la página de login para mostrar mensajes de éxito/error relacionados con el reseteo.